### PR TITLE
DEVOPS-1842 Merge master into branch "instance-template/disk-variables" for TF v0.13 support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@
 ---
 driver:
   name: terraform
+  verify_version: false
 
 provisioner:
   name: terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [5.1.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v5.0.0...v5.1.0) (2020-10-07)
+
+
+### Features
+
+* Added instance_group_manager output ([#105](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/105)) ([e8a174a](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/e8a174aa899f9ade792d1576689603eab6ca774e))
+
 ## [5.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v4.0.0...v5.0.0) (2020-09-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [6.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v5.1.0...v6.0.0) (2020-12-08)
+
+
+### ⚠ BREAKING CHANGES
+
+* Minimum Terraform version increased to 0.13.
+* Update default source image and family to latest CentOS 7 (#126)
+
+### Features
+
+* add TF 0.13 constraint and module attribution ([#128](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/128)) ([d042aae](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/d042aae0ab50fbbe763ff551f3daa80aa8f1b551))
+* adds an output for the health check self_links to be consumed by load balancer resources outside this module ([#119](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/119)) ([ae4d777](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/ae4d7777958fe4238d96191a3aa7c7deab996fd1))
+* Update default source image and family to latest CentOS 7 ([#126](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/126)) ([6310016](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/63100169ebecea163f3965f4be3df8b600af047d))
+
 ## [5.1.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v5.0.0...v5.1.0) (2020-10-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [4.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v3.0.0...v4.0.0) (2020-06-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* instance_redistribution_type must now be specified for update policies.
+
+### Features
+
+* Add stateful disk support ([#90](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/90)) ([645e845](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/645e8453e945fe6f7b1c5cccd7ad557f5355cc10))
+* Add wait_for_instances and configurable timeout support for mig ([#96](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/96)) ([10a23b7](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/10a23b70250bd26ed9820184b535e4ce99d24ec7))
+
 ## [3.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v2.1.0...v3.0.0) (2020-05-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [5.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v4.0.0...v5.0.0) (2020-09-15)
+
+
+### ⚠ BREAKING CHANGES
+
+* **UMIG:** var.access_config has been changed to a 2D array, with a separate element for each VM.
+
+### Bug Fixes
+
+* **UMIG:** access_config should be 2D array ([#111](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/111)) ([69f7520](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/69f752033453ceb2ee50a8d5614112ce96b60650))
+* relax version constraints to enable terraform 0.13.x compatibility ([#108](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/108)) ([6fb2b42](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/6fb2b42bd96f90d3c2baffd511cb58200fbc074c))
+* Terraform version upgrade for compute_instance module from 0.12.6 to 0.12.7 ([#103](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/103)) ([7a21e78](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/7a21e788f6ded801be8d3354bfd31934aca5b7fb))
+
 ## [4.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v3.0.0...v4.0.0) (2020-06-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [3.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v2.1.0...v3.0.0) (2020-05-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* The preemptible_and_regular_instance_templates modules have had name_prefixes renamed, forcing instances to be recreated.
+
+### Features
+
+* Add support for assigning public IPs directly to instances. ([#83](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/83)) ([dde01ff](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/dde01ff376a8e58b4a365724cb4531a4e24435a5))
+
+
+### Bug Fixes
+
+* Correct names for instances in preemptible and regular instance module ([#81](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/81)) ([5a6ec12](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/5a6ec12c3d26c88e45fe4b1a1d919562b4995f24))
+
 ## [2.1.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v2.0.0...v2.1.0) (2020-03-05)
 
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.2
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.13
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.2
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is a collection of opinionated submodules that can be used as building bloc
 
 ## Compatibility
 
- This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html)
-  and need a Terraform 0.11.x-compatible version of this module, the last released version intended for
-  Terraform 0.11.x is [0.2.0](https://registry.terraform.io/modules/terraform-google-modules/vm/google/0.2.0).
+ This module is meant for use with Terraform 0.13. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-13.html)
+  and need a Terraform 0.12.x-compatible version of this module, the last released version intended for
+  Terraform 0.12.x is [5.1.0](https://registry.terraform.io/modules/terraform-google-modules/vm/google/5.1.0).
 
 
 ## Examples

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -71,6 +71,8 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? null : var.target_size
 
+  wait_for_instances = var.wait_for_instances
+
   dynamic "auto_healing_policies" {
     for_each = local.healthchecks
     content {
@@ -91,19 +93,26 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
   dynamic "update_policy" {
     for_each = var.update_policy
     content {
-      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
-      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
-      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
-      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
-      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
-      minimal_action          = update_policy.value.minimal_action
-      type                    = update_policy.value.type
+      instance_redistribution_type = lookup(update_policy.value, "instance_redistribution_type", null)
+      max_surge_fixed              = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent            = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed        = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent      = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec                = lookup(update_policy.value, "min_ready_sec", null)
+      minimal_action               = update_policy.value.minimal_action
+      type                         = update_policy.value.type
     }
   }
 
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [distribution_policy_zones]
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
   }
 }
 
@@ -143,7 +152,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   }
   {% if mig_with_percent %}
 
-  depends_on = ["google_compute_region_instance_group_manager.mig_with_percent"]
+  depends_on = [google_compute_region_instance_group_manager.mig_with_percent]
   {% endif %}
 }
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -79,6 +79,14 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
     }
   }
 
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -106,7 +106,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   project  = var.project_id
   region   = var.region
 
-  target   = google_compute_region_instance_group_manager.{{ module_name }}.self_link
+  target = google_compute_region_instance_group_manager.{{ module_name }}.self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -29,12 +29,8 @@ locals {
 }
 
 data "google_compute_zones" "available" {
-  {% if mig %}
   project = var.project_id
   region  = var.region
-  {% else %}
-  region = var.region
-  {% endif %}
 }
 
 resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
@@ -108,9 +104,8 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   count    = var.autoscaling_enabled ? 1 : 0
   name     = "${var.hostname}-autoscaler"
   project  = var.project_id
-  {% if mig %}
   region   = var.region
-  {% endif %}
+
   target   = google_compute_region_instance_group_manager.{{ module_name }}.self_link
 
   autoscaling_policy {

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -25,3 +25,8 @@ output "instance_group" {
   description = "Instance-group url of managed instance group"
   value       = google_compute_region_instance_group_manager.{{ module_name }}.instance_group
 }
+
+output "instance_group_manager" {
+  description = "An instance of google_compute_region_instance_group_manager of the instance group."
+  value       = google_compute_region_instance_group_manager.{{ module_name }}
+}

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -30,3 +30,8 @@ output "instance_group_manager" {
   description = "An instance of google_compute_region_instance_group_manager of the instance group."
   value       = google_compute_region_instance_group_manager.{{ module_name }}
 }
+
+output "health_check_self_links" {
+  description = "All self_links of healthchecks created for the instance group."
+  value       = local.healthchecks
+}

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -86,13 +86,14 @@ variable "stateful_disks" {
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }
@@ -202,4 +203,23 @@ variable "named_ports" {
     port = number
   }))
   default = []
+}
+
+variable "wait_for_instances" {
+  description = "Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out."
+  default     = "false"
+}
+
+variable "mig_timeouts" {
+  description = "Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. "
+  type = object({
+    create = string
+    update = string
+    delete = string
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "15m"
+  }
 }

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -68,6 +68,18 @@ variable "distribution_policy_zones" {
 }
 
 #################
+# Stateful disks
+#################
+variable "stateful_disks" {
+  description = "Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs"
+  type = list(object({
+    device_name = string
+    delete_rule = string
+  }))
+  default = []
+}
+
+#################
 # Rolling Update
 #################
 

--- a/autogen/versions.tf
+++ b/autogen/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/autogen/versions.tf.tmpl
+++ b/autogen/versions.tf.tmpl
@@ -15,9 +15,15 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
   required_providers {
-    google      = ">= 2.7, <4.0"
-    google-beta = ">= 2.7, <4.0"
+    google      = ">= 3.43, <4.0"
+    google-beta = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:{% if mig %}mig{% else %}mig_with_percent{% endif %}/v6.0.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-google-vm:{% if mig %}mig{% else %}mig_with_percent{% endif %}/v6.0.0"
   }
 }

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -246,4 +246,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -246,4 +246,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -246,4 +246,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'

--- a/examples/compute_instance/simple/README.md
+++ b/examples/compute_instance/simple/README.md
@@ -6,14 +6,14 @@ This is a simple, minimal example of how to use the compute_instance module
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| nat\_ip | Public ip address | string | `"null"` | no |
-| network\_tier | Network network_tier | string | `"PREMIUM"` | no |
-| num\_instances | Number of instances to create | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork selflink to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| nat\_ip | Public ip address | `any` | `null` | no |
+| network\_tier | Network network\_tier | `string` | `"PREMIUM"` | no |
+| num\_instances | Number of instances to create | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork selflink to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/compute_instance/simple/README.md
+++ b/examples/compute_instance/simple/README.md
@@ -7,6 +7,8 @@ This is a simple, minimal example of how to use the compute_instance module
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| nat\_ip | Public ip address | string | `"null"` | no |
+| network\_tier | Network network_tier | string | `"PREMIUM"` | no |
 | num\_instances | Number of instances to create | string | n/a | yes |
 | project\_id | The GCP project to use for integration tests | string | n/a | yes |
 | region | The GCP region to create and test resources in | string | `"us-central1"` | no |

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -34,4 +34,8 @@ module "compute_instance" {
   num_instances     = var.num_instances
   hostname          = "instance-simple"
   instance_template = module.instance_template.self_link
+  access_config = [{
+    nat_ip       = var.nat_ip
+    network_tier = var.network_tier
+  }, ]
 }

--- a/examples/compute_instance/simple/variables.tf
+++ b/examples/compute_instance/simple/variables.tf
@@ -35,6 +35,15 @@ variable "num_instances" {
   description = "Number of instances to create"
 }
 
+variable "nat_ip" {
+  description = "Public ip address"
+  default     = null
+}
+
+variable "network_tier" {
+  description = "Network network_tier"
+  default     = "PREMIUM"
+}
 
 
 variable "service_account" {

--- a/examples/compute_instance/simple/versions.tf
+++ b/examples/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/compute_instance/simple/versions.tf
+++ b/examples/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/instance_template/additional_disks/README.md
+++ b/examples/instance_template/additional_disks/README.md
@@ -7,11 +7,11 @@ instance templates with additional persistent disks.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The name of the subnetwork create this instance in. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/instance_template/additional_disks/versions.tf
+++ b/examples/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/instance_template/additional_disks/versions.tf
+++ b/examples/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/instance_template/simple/README.md
+++ b/examples/instance_template/simple/README.md
@@ -6,13 +6,13 @@ This is a simple, minimal example of how to use the instance_template module.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| labels | Labels, provided as a map | map(string) | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| labels | Labels, provided as a map | `map(string)` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The name of the subnetwork create this instance in. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/instance_template/simple/versions.tf
+++ b/examples/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/instance_template/simple/versions.tf
+++ b/examples/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/mig/autoscaler/README.md
+++ b/examples/mig/autoscaler/README.md
@@ -7,14 +7,14 @@ group with an autoscaler.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list(map(number)) | n/a | yes |
-| autoscaling\_enabled | Creates an autoscaler for the managed instance group | string | n/a | yes |
-| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | `list(map(number))` | n/a | yes |
+| autoscaling\_enabled | Creates an autoscaler for the managed instance group | `any` | n/a | yes |
+| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/mig/autoscaler/versions.tf
+++ b/examples/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/autoscaler/versions.tf
+++ b/examples/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/mig/full/variables.tf
+++ b/examples/mig/full/variables.tf
@@ -179,13 +179,14 @@ variable "distribution_policy_zones" {
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }
@@ -268,4 +269,3 @@ variable "autoscaling_enabled" {
   type        = bool
   default     = false
 }
-

--- a/examples/mig/full/versions.tf
+++ b/examples/mig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/full/versions.tf
+++ b/examples/mig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/mig/simple/README.md
+++ b/examples/mig/simple/README.md
@@ -7,12 +7,12 @@ managed instance group.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
-| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
+| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/mig/simple/versions.tf
+++ b/examples/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/simple/versions.tf
+++ b/examples/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/mig_with_percent/simple/README.md
+++ b/examples/mig_with_percent/simple/README.md
@@ -7,11 +7,11 @@ managed instance group.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account email address and scopes | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account email address and scopes | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/mig_with_percent/simple/versions.tf
+++ b/examples/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig_with_percent/simple/versions.tf
+++ b/examples/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/preemptible_and_regular_instance_templates/simple/README.md
+++ b/examples/preemptible_and_regular_instance_templates/simple/README.md
@@ -6,13 +6,13 @@ This creates instance templates for both preemptible VM and regular VM
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| labels | Labels, provided as a map | map(string) | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| labels | Labels, provided as a map | `map(string)` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The name of the subnetwork create this instance in. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/umig/full/main.tf
+++ b/examples/umig/full/main.tf
@@ -73,5 +73,5 @@ module "umig" {
   instance_template  = module.instance_template.self_link
   named_ports        = var.named_ports
   region             = var.region
-  access_config      = [local.access_config]
+  access_config      = [[local.access_config]]
 }

--- a/examples/umig/full/versions.tf
+++ b/examples/umig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/full/versions.tf
+++ b/examples/umig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/umig/named_ports/README.md
+++ b/examples/umig/named_ports/README.md
@@ -7,13 +7,13 @@ groups with named ports
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| named\_ports | Named name and named port | object | `<list>` | no |
-| num\_instances | Number of instances to create | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| num\_instances | Number of instances to create | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/umig/named_ports/versions.tf
+++ b/examples/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/named_ports/versions.tf
+++ b/examples/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/umig/simple/README.md
+++ b/examples/umig/simple/README.md
@@ -6,12 +6,12 @@ This is a simple, minimal example of how to use the UMIG module
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| num\_instances | Number of instances to create | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| num\_instances | Number of instances to create | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/umig/simple/versions.tf
+++ b/examples/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/simple/versions.tf
+++ b/examples/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/examples/umig/static_ips/README.md
+++ b/examples/umig/static_ips/README.md
@@ -7,13 +7,13 @@ instance groups with user-specified static IPs.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| num\_instances | Number of instances to create | string | `"1"` | no |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| static\_ips | List of static IPs for VM instances | list(string) | n/a | yes |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| num\_instances | Number of instances to create | `string` | `"1"` | no |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| static\_ips | List of static IPs for VM instances | `list(string)` | n/a | yes |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/umig/static_ips/versions.tf
+++ b/examples/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/static_ips/versions.tf
+++ b/examples/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -14,16 +14,16 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| hostname | Hostname of instances | string | `""` | no |
-| instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| num\_instances | Number of instances to create. This value is ignored if static_ips is provided. | string | `"1"` | no |
-| region | Region where the instances should be created. | string | `"null"` | no |
-| static\_ips | List of static IPs for VM instances | list(string) | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| hostname | Hostname of instances | `string` | `""` | no |
+| instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |
+| region | Region where the instances should be created. | `string` | `null` | no |
+| static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -5,7 +5,7 @@ This module is used to create compute instances (and only compute instances) usi
 
 ## Usage
 
-See the [simple](examples/compute_instance/simple) for a usage example.
+See the [simple](https://github.com/terraform-google-modules/terraform-google-vm/tree/master/examples/compute_instance/simple) for a usage example.
 
 ## Testing
 

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -15,6 +15,7 @@ See the [simple](examples/compute_instance/simple) for a usage example.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
 | hostname | Hostname of instances | string | `""` | no |
 | instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -50,6 +50,13 @@ resource "google_compute_instance_from_template" "compute_instance" {
     subnetwork         = var.subnetwork
     subnetwork_project = var.subnetwork_project
     network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, count.index)
+    dynamic "access_config" {
+      for_each = var.access_config
+      content {
+        nat_ip       = access_config.value.nat_ip
+        network_tier = access_config.value.network_tier
+      }
+    }
   }
 
   source_instance_template = var.instance_template

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -40,6 +40,15 @@ variable "static_ips" {
   default     = []
 }
 
+variable "access_config" {
+  description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
+  type = list(object({
+    nat_ip       = string
+    network_tier = string
+  }))
+  default = []
+}
+
 variable "num_instances" {
   description = "Number of instances to create. This value is ignored if static_ips is provided."
   default     = "1"

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,8 +15,11 @@
  */
 
 terraform {
-  required_version = ">=0.12.7, <0.14"
+  required_version = ">=0.13.0"
   required_providers {
-    google = ">= 2.7, <4.0"
+    google = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:compute_instance/v6.0.0"
   }
 }

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.7, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -14,31 +14,31 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | object | `<list>` | no |
-| auto\_delete | Whether or not the boot disk should be auto-deleted | string | `"true"` | no |
-| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | string | `"false"` | no |
-| disk\_size\_gb | Boot disk size in GB | string | `"100"` | no |
-| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | string | `"pd-standard"` | no |
-| enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | string | `"false"` | no |
-| labels | Labels, provided as a map | map(string) | `<map>` | no |
-| machine\_type | Machine type to create, e.g. n1-standard-1 | string | `"n1-standard-1"` | no |
-| metadata | Metadata, provided as a map | map(string) | `<map>` | no |
-| name\_prefix | Name prefix for the instance template | string | `"default-instance-template"` | no |
-| network | The name or self_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | string | `""` | no |
-| preemptible | Allow the instance to be preempted | bool | `"false"` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | Region where the instance template should be created. | string | `"null"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | n/a | yes |
-| shielded\_instance\_config | Not used unless enable_shielded_vm is true. Shielded VM configuration for the instance. | object | `<map>` | no |
-| source\_image | Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `""` | no |
-| source\_image\_family | Source image family. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `"centos-7"` | no |
-| source\_image\_project | Project where the source image comes from. The default project contains images that support Shielded VMs if desired | string | `"gce-uefi-images"` | no |
-| startup\_script | User startup script to run when instances spin up | string | `""` | no |
-| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | string | `""` | no |
-| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | `<list>` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| auto\_delete | Whether or not the boot disk should be auto-deleted | `string` | `"true"` | no |
+| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
+| disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
+| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
+| enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
+| labels | Labels, provided as a map | `map(string)` | `{}` | no |
+| machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
+| metadata | Metadata, provided as a map | `map(string)` | `{}` | no |
+| name\_prefix | Name prefix for the instance template | `string` | `"default-instance-template"` | no |
+| network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
+| preemptible | Allow the instance to be preempted | `bool` | `false` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | Region where the instance template should be created. | `string` | `null` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
+| shielded\_instance\_config | Not used unless enable\_shielded\_vm is true. Shielded VM configuration for the instance. | <pre>object({<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>    enable_integrity_monitoring = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
+| source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `"centos-7"` | no |
+| source\_image\_project | Project where the source image comes from. The default project contains images that support Shielded VMs if desired | `string` | `"gce-uefi-images"` | no |
+| startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
+| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
+| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -1,6 +1,6 @@
 # instance_template
 
-This submodule allows you to create an `google_compute_instance_template`
+This submodule allows you to create a `google_compute_instance_template`
 resource, which is used as the basis for the other instance, managed, and
 unmanaged instance groups submodules.
 

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -19,12 +19,12 @@
 ###############
 data "google_compute_image" "image" {
   project = var.source_image != "" ? var.source_image_project : "centos-cloud"
-  name    = var.source_image != "" ? var.source_image : "centos-6-v20180716"
+  name    = var.source_image != "" ? var.source_image : "centos-7-v20201112"
 }
 
 data "google_compute_image" "image_family" {
   project = var.source_image_family != "" ? var.source_image_project : "centos-cloud"
-  family  = var.source_image_family != "" ? var.source_image_family : "centos-6"
+  family  = var.source_image_family != "" ? var.source_image_family : "centos-7"
 }
 
 #########

--- a/modules/instance_template/versions.tf
+++ b/modules/instance_template/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/instance_template/versions.tf
+++ b/modules/instance_template/versions.tf
@@ -15,8 +15,11 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
   required_providers {
-    google = ">= 2.7, <4.0"
+    google = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:instance_template/v6.0.0"
   }
 }

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -47,6 +47,7 @@ The current version is 2.X. The following guides are available to assist with up
 | Name | Description |
 |------|-------------|
 | instance\_group | Instance-group url of managed instance group |
+| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -17,37 +17,38 @@ The current version is 2.X. The following guides are available to assist with up
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_enabled | Creates an autoscaler for the managed instance group | string | `"false"` | no |
-| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | object | `<list>` | no |
-| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | string | `"60"` | no |
-| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | list(string) | `<list>` | no |
-| health\_check | Health check to determine whether instances are responsive and able to do work | object | `<map>` | no |
-| hostname | Hostname prefix for instances | string | `"default"` | no |
-| instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
-| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
-| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
-| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
-| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | The GCP region where the managed instance group resides. | string | n/a | yes |
-| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
-| target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
-| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
-| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
-| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_enabled | Creates an autoscaler for the managed instance group | `string` | `"false"` | no |
+| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | <pre>list(object({<br>    name   = string<br>    target = number<br>    type   = string<br>  }))</pre> | `[]` | no |
+| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | `number` | `60` | no |
+| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | `list(string)` | `[]` | no |
+| health\_check | Health check to determine whether instances are responsive and able to do work | <pre>object({<br>    type                = string<br>    initial_delay_sec   = number<br>    check_interval_sec  = number<br>    healthy_threshold   = number<br>    timeout_sec         = number<br>    unhealthy_threshold = number<br>    response            = string<br>    proxy_header        = string<br>    port                = number<br>    request             = string<br>    request_path        = string<br>    host                = string<br>  })</pre> | <pre>{<br>  "check_interval_sec": 30,<br>  "healthy_threshold": 1,<br>  "host": "",<br>  "initial_delay_sec": 30,<br>  "port": 80,<br>  "proxy_header": "NONE",<br>  "request": "",<br>  "request_path": "/",<br>  "response": "",<br>  "timeout_sec": 10,<br>  "type": "",<br>  "unhealthy_threshold": 5<br>}</pre> | no |
+| hostname | Hostname prefix for instances | `string` | `"default"` | no |
+| instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
+| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
+| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
+| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | The GCP region where the managed instance group resides. | `any` | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | <pre>list(object({<br>    device_name = string<br>    delete_rule = string<br>  }))</pre> | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
+| target\_pools | The target load balancing pools to assign this group to. | `list(string)` | `[]` | no |
+| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | `number` | `1` | no |
+| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | <pre>list(object({<br>    max_surge_fixed              = number<br>    instance_redistribution_type = string<br>    max_surge_percent            = number<br>    max_unavailable_fixed        = number<br>    max_unavailable_percent      = number<br>    min_ready_sec                = number<br>    minimal_action               = string<br>    type                         = string<br>  }))</pre> | `[]` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | `string` | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| health\_check\_self\_links | All self\_links of healthchecks created for the instance group. |
 | instance\_group | Instance-group url of managed instance group |
-| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
+| instance\_group\_manager | An instance of google\_compute\_region\_instance\_group\_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -28,16 +28,19 @@ The current version is 2.X. The following guides are available to assist with up
 | hostname | Hostname prefix for instances | string | `"default"` | no |
 | instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | project\_id | The GCP project ID | string | `"null"` | no |
 | region | The GCP region where the managed instance group resides. | string | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
 | target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
 | target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
 | update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
 
 ## Outputs
 

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -55,6 +55,8 @@ resource "google_compute_region_instance_group_manager" "mig" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? null : var.target_size
 
+  wait_for_instances = var.wait_for_instances
+
   dynamic "auto_healing_policies" {
     for_each = local.healthchecks
     content {
@@ -89,6 +91,12 @@ resource "google_compute_region_instance_group_manager" "mig" {
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [distribution_policy_zones]
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
   }
 }
 

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -90,7 +90,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   project  = var.project_id
   region   = var.region
 
-  target   = google_compute_region_instance_group_manager.mig.self_link
+  target = google_compute_region_instance_group_manager.mig.self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -89,6 +89,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   name     = "${var.hostname}-autoscaler"
   project  = var.project_id
   region   = var.region
+
   target   = google_compute_region_instance_group_manager.mig.self_link
 
   autoscaling_policy {

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -63,17 +63,26 @@ resource "google_compute_region_instance_group_manager" "mig" {
     }
   }
 
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy
     content {
-      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
-      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
-      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
-      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
-      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
-      minimal_action          = update_policy.value.minimal_action
-      type                    = update_policy.value.type
+      instance_redistribution_type = lookup(update_policy.value, "instance_redistribution_type", null)
+      max_surge_fixed              = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent            = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed        = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent      = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec                = lookup(update_policy.value, "min_ready_sec", null)
+      minimal_action               = update_policy.value.minimal_action
+      type                         = update_policy.value.type
     }
   }
 

--- a/modules/mig/outputs.tf
+++ b/modules/mig/outputs.tf
@@ -25,3 +25,8 @@ output "instance_group" {
   description = "Instance-group url of managed instance group"
   value       = google_compute_region_instance_group_manager.mig.instance_group
 }
+
+output "instance_group_manager" {
+  description = "An instance of google_compute_region_instance_group_manager of the instance group."
+  value       = google_compute_region_instance_group_manager.mig
+}

--- a/modules/mig/outputs.tf
+++ b/modules/mig/outputs.tf
@@ -30,3 +30,8 @@ output "instance_group_manager" {
   description = "An instance of google_compute_region_instance_group_manager of the instance group."
   value       = google_compute_region_instance_group_manager.mig
 }
+
+output "health_check_self_links" {
+  description = "All self_links of healthchecks created for the instance group."
+  value       = local.healthchecks
+}

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -53,19 +53,31 @@ variable "distribution_policy_zones" {
 }
 
 #################
+# Stateful disks
+#################
+variable "stateful_disks" {
+  description = "Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs"
+  type = list(object({
+    device_name = string
+    delete_rule = string
+  }))
+  default = []
+}
+#################
 # Rolling Update
 #################
 
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -63,6 +63,7 @@ variable "stateful_disks" {
   }))
   default = []
 }
+
 #################
 # Rolling Update
 #################
@@ -187,4 +188,23 @@ variable "named_ports" {
     port = number
   }))
   default = []
+}
+
+variable "wait_for_instances" {
+  description = "Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out."
+  default     = "false"
+}
+
+variable "mig_timeouts" {
+  description = "Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. "
+  type = object({
+    create = string
+    update = string
+    delete = string
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "15m"
+  }
 }

--- a/modules/mig/versions.tf
+++ b/modules/mig/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/modules/mig/versions.tf
+++ b/modules/mig/versions.tf
@@ -15,9 +15,15 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
   required_providers {
-    google      = ">= 2.7, <4.0"
-    google-beta = ">= 2.7, <4.0"
+    google      = ">= 3.43, <4.0"
+    google-beta = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:mig/v6.0.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-google-vm:mig/v6.0.0"
   }
 }

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -48,6 +48,7 @@ The current version is 2.X. The following guides are available to assist with up
 | Name | Description |
 |------|-------------|
 | instance\_group | Instance-group url of managed instance group |
+| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -16,39 +16,40 @@ The current version is 2.X. The following guides are available to assist with up
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_enabled | Creates an autoscaler for the managed instance group | string | `"false"` | no |
-| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | object | `<list>` | no |
-| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | string | `"60"` | no |
-| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | list(string) | `<list>` | no |
-| health\_check | Health check to determine whether instances are responsive and able to do work | object | `<map>` | no |
-| hostname | Hostname prefix for instances | string | `"default"` | no |
-| instance\_template\_initial\_version | Instance template self_link used to create compute instances for the initial version | string | n/a | yes |
-| instance\_template\_next\_version | Instance template self_link used to create compute instances for the second version | string | n/a | yes |
-| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
-| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
-| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
-| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| next\_version\_percent | Percentage of instances defined in the second version | string | n/a | yes |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | The GCP region where the managed instance group resides. | string | n/a | yes |
-| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
-| target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
-| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
-| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
-| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_enabled | Creates an autoscaler for the managed instance group | `string` | `"false"` | no |
+| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | <pre>list(object({<br>    name   = string<br>    target = number<br>    type   = string<br>  }))</pre> | `[]` | no |
+| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | `number` | `60` | no |
+| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | `list(string)` | `[]` | no |
+| health\_check | Health check to determine whether instances are responsive and able to do work | <pre>object({<br>    type                = string<br>    initial_delay_sec   = number<br>    check_interval_sec  = number<br>    healthy_threshold   = number<br>    timeout_sec         = number<br>    unhealthy_threshold = number<br>    response            = string<br>    proxy_header        = string<br>    port                = number<br>    request             = string<br>    request_path        = string<br>    host                = string<br>  })</pre> | <pre>{<br>  "check_interval_sec": 30,<br>  "healthy_threshold": 1,<br>  "host": "",<br>  "initial_delay_sec": 30,<br>  "port": 80,<br>  "proxy_header": "NONE",<br>  "request": "",<br>  "request_path": "/",<br>  "response": "",<br>  "timeout_sec": 10,<br>  "type": "",<br>  "unhealthy_threshold": 5<br>}</pre> | no |
+| hostname | Hostname prefix for instances | `string` | `"default"` | no |
+| instance\_template\_initial\_version | Instance template self\_link used to create compute instances for the initial version | `any` | n/a | yes |
+| instance\_template\_next\_version | Instance template self\_link used to create compute instances for the second version | `any` | n/a | yes |
+| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
+| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
+| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| next\_version\_percent | Percentage of instances defined in the second version | `any` | n/a | yes |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | The GCP region where the managed instance group resides. | `any` | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | <pre>list(object({<br>    device_name = string<br>    delete_rule = string<br>  }))</pre> | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
+| target\_pools | The target load balancing pools to assign this group to. | `list(string)` | `[]` | no |
+| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | `number` | `1` | no |
+| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | <pre>list(object({<br>    max_surge_fixed              = number<br>    instance_redistribution_type = string<br>    max_surge_percent            = number<br>    max_unavailable_fixed        = number<br>    max_unavailable_percent      = number<br>    min_ready_sec                = number<br>    minimal_action               = string<br>    type                         = string<br>  }))</pre> | `[]` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | `string` | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| health\_check\_self\_links | All self\_links of healthchecks created for the instance group. |
 | instance\_group | Instance-group url of managed instance group |
-| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
+| instance\_group\_manager | An instance of google\_compute\_region\_instance\_group\_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -28,17 +28,20 @@ The current version is 2.X. The following guides are available to assist with up
 | instance\_template\_initial\_version | Instance template self_link used to create compute instances for the initial version | string | n/a | yes |
 | instance\_template\_next\_version | Instance template self_link used to create compute instances for the second version | string | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | next\_version\_percent | Percentage of instances defined in the second version | string | n/a | yes |
 | project\_id | The GCP project ID | string | `"null"` | no |
 | region | The GCP region where the managed instance group resides. | string | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
 | target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
 | target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
 | update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
 
 ## Outputs
 

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -64,6 +64,8 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? null : var.target_size
 
+  wait_for_instances = var.wait_for_instances
+
   dynamic "auto_healing_policies" {
     for_each = local.healthchecks
     content {
@@ -72,23 +74,38 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
     }
   }
 
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy
     content {
-      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
-      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
-      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
-      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
-      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
-      minimal_action          = update_policy.value.minimal_action
-      type                    = update_policy.value.type
+      instance_redistribution_type = lookup(update_policy.value, "instance_redistribution_type", null)
+      max_surge_fixed              = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent            = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed        = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent      = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec                = lookup(update_policy.value, "min_ready_sec", null)
+      minimal_action               = update_policy.value.minimal_action
+      type                         = update_policy.value.type
     }
   }
 
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [distribution_policy_zones]
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
   }
 }
 
@@ -127,7 +144,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
     }
   }
 
-  depends_on = ["google_compute_region_instance_group_manager.mig_with_percent"]
+  depends_on = [google_compute_region_instance_group_manager.mig_with_percent]
 }
 
 resource "google_compute_health_check" "http" {

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   project  = var.project_id
   region   = var.region
 
-  target   = google_compute_region_instance_group_manager.mig_with_percent.self_link
+  target = google_compute_region_instance_group_manager.mig_with_percent.self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -29,7 +29,8 @@ locals {
 }
 
 data "google_compute_zones" "available" {
-  region = var.region
+  project = var.project_id
+  region  = var.region
 }
 
 resource "google_compute_region_instance_group_manager" "mig_with_percent" {
@@ -96,6 +97,8 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   count    = var.autoscaling_enabled ? 1 : 0
   name     = "${var.hostname}-autoscaler"
   project  = var.project_id
+  region   = var.region
+
   target   = google_compute_region_instance_group_manager.mig_with_percent.self_link
 
   autoscaling_policy {

--- a/modules/mig_with_percent/outputs.tf
+++ b/modules/mig_with_percent/outputs.tf
@@ -30,3 +30,8 @@ output "instance_group_manager" {
   description = "An instance of google_compute_region_instance_group_manager of the instance group."
   value       = google_compute_region_instance_group_manager.mig_with_percent
 }
+
+output "health_check_self_links" {
+  description = "All self_links of healthchecks created for the instance group."
+  value       = local.healthchecks
+}

--- a/modules/mig_with_percent/outputs.tf
+++ b/modules/mig_with_percent/outputs.tf
@@ -25,3 +25,8 @@ output "instance_group" {
   description = "Instance-group url of managed instance group"
   value       = google_compute_region_instance_group_manager.mig_with_percent.instance_group
 }
+
+output "instance_group_manager" {
+  description = "An instance of google_compute_region_instance_group_manager of the instance group."
+  value       = google_compute_region_instance_group_manager.mig_with_percent
+}

--- a/modules/mig_with_percent/variables.tf
+++ b/modules/mig_with_percent/variables.tf
@@ -61,19 +61,32 @@ variable "distribution_policy_zones" {
 }
 
 #################
+# Stateful disks
+#################
+variable "stateful_disks" {
+  description = "Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs"
+  type = list(object({
+    device_name = string
+    delete_rule = string
+  }))
+  default = []
+}
+
+#################
 # Rolling Update
 #################
 
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }
@@ -183,4 +196,23 @@ variable "named_ports" {
     port = number
   }))
   default = []
+}
+
+variable "wait_for_instances" {
+  description = "Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out."
+  default     = "false"
+}
+
+variable "mig_timeouts" {
+  description = "Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. "
+  type = object({
+    create = string
+    update = string
+    delete = string
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "15m"
+  }
 }

--- a/modules/mig_with_percent/versions.tf
+++ b/modules/mig_with_percent/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/modules/mig_with_percent/versions.tf
+++ b/modules/mig_with_percent/versions.tf
@@ -15,9 +15,15 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
   required_providers {
-    google      = ">= 2.7, <4.0"
-    google-beta = ">= 2.7, <4.0"
+    google      = ">= 3.43, <4.0"
+    google-beta = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:mig_with_percent/v6.0.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-google-vm:mig_with_percent/v6.0.0"
   }
 }

--- a/modules/preemptible_and_regular_instance_templates/README.md
+++ b/modules/preemptible_and_regular_instance_templates/README.md
@@ -11,27 +11,27 @@ See the [simple](../../examples/preemptible_and_regular_instance_templates/simpl
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | object | `<list>` | no |
-| auto\_delete | Whether or not the boot disk should be auto-deleted | string | `"true"` | no |
-| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | string | `"false"` | no |
-| disk\_size\_gb | Boot disk size in GB | string | `"100"` | no |
-| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | string | `"pd-standard"` | no |
-| labels | Labels, provided as a map | map(string) | `<map>` | no |
-| machine\_type | Machine type to create, e.g. n1-standard-1 | string | `"n1-standard-1"` | no |
-| metadata | Metadata, provided as a map | map(string) | `<map>` | no |
-| name\_prefix | Name prefix for the instance template | string | `"default-it"` | no |
-| network | The name or self_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | string | `""` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | n/a | yes |
-| source\_image | Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `""` | no |
-| source\_image\_family | Source image family. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `""` | no |
-| source\_image\_project | Project where the source image comes from | string | `""` | no |
-| startup\_script | User startup script to run when instances spin up | string | `""` | no |
-| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | string | `""` | no |
-| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | `<list>` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| auto\_delete | Whether or not the boot disk should be auto-deleted | `bool` | `true` | no |
+| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
+| disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
+| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
+| labels | Labels, provided as a map | `map(string)` | `{}` | no |
+| machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
+| metadata | Metadata, provided as a map | `map(string)` | `{}` | no |
+| name\_prefix | Name prefix for the instance template | `string` | `"default-it"` | no |
+| network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
+| source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
+| source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
+| source\_image\_project | Project where the source image comes from | `string` | `""` | no |
+| startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
+| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
+| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/preemptible_and_regular_instance_templates/main.tf
+++ b/modules/preemptible_and_regular_instance_templates/main.tf
@@ -20,7 +20,7 @@
 
 module "preemptible" {
   source               = "../../modules/instance_template"
-  name_prefix          = "${var.name_prefix}-regular"
+  name_prefix          = "${var.name_prefix}-preemptible"
   project_id           = var.project_id
   machine_type         = var.machine_type
   labels               = var.labels
@@ -45,7 +45,7 @@ module "preemptible" {
 
 module "regular" {
   source               = "../../modules/instance_template"
-  name_prefix          = "${var.name_prefix}-preemptible"
+  name_prefix          = "${var.name_prefix}-regular"
   project_id           = var.project_id
   machine_type         = var.machine_type
   labels               = var.labels

--- a/modules/preemptible_and_regular_instance_templates/versions.tf
+++ b/modules/preemptible_and_regular_instance_templates/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/preemptible_and_regular_instance_templates/versions.tf
+++ b/modules/preemptible_and_regular_instance_templates/versions.tf
@@ -15,5 +15,15 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
+  required_providers {
+    google      = ">= 3.43, <4.0"
+    google-beta = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:preemptible_and_regular_instance_templates/v6.0.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-google-vm:preemptible_and_regular_instance_templates/v6.0.0"
+  }
 }

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -14,18 +14,18 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| hostname | Hostname of instances | string | `""` | no |
-| instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
-| named\_ports | Named name and named port | object | `<list>` | no |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| num\_instances | Number of instances to create. This value is ignored if static_ips is provided. | string | `"1"` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | The GCP region where the unmanaged instance group resides. | string | n/a | yes |
-| static\_ips | List of static IPs for VM instances | list(string) | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  })))</pre> | `[]` | no |
+| hostname | Hostname of instances | `string` | `""` | no |
+| instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
+| named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | The GCP region where the unmanaged instance group resides. | `string` | n/a | yes |
+| static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -5,7 +5,7 @@ This module is used to create compute instances using
 
 ## Usage
 
-See the [simple](examples/umig/simple) for a usage example.
+See the [simple](https://github.com/terraform-google-modules/terraform-google-vm/tree/master/examples/umig/simple) for a usage example.
 
 ## Testing
 

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -56,7 +56,8 @@ resource "google_compute_instance_from_template" "compute_instance" {
     network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, count.index)
 
     dynamic "access_config" {
-      for_each = var.access_config
+      # convert to map to use lookup function with default value
+      for_each = lookup({ for k, v in var.access_config : k => v }, count.index, [])
       content {
         nat_ip       = access_config.value.nat_ip
         network_tier = access_config.value.network_tier

--- a/modules/umig/variables.tf
+++ b/modules/umig/variables.tf
@@ -71,9 +71,9 @@ variable "instance_template" {
 
 variable "access_config" {
   description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
-  type = list(object({
+  type = list(list(object({
     nat_ip       = string
     network_tier = string
-  }))
+  })))
   default = []
 }

--- a/modules/umig/versions.tf
+++ b/modules/umig/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/umig/versions.tf
+++ b/modules/umig/versions.tf
@@ -15,8 +15,11 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.13.0"
   required_providers {
-    google = ">= 2.7, <4.0"
+    google = ">= 3.43, <4.0"
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-vm:umig/v6.0.0"
   }
 }

--- a/test/fixtures/compute_instance/simple/versions.tf
+++ b/test/fixtures/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/compute_instance/simple/versions.tf
+++ b/test/fixtures/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/instance_template/additional_disks/versions.tf
+++ b/test/fixtures/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/instance_template/additional_disks/versions.tf
+++ b/test/fixtures/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/instance_template/simple/versions.tf
+++ b/test/fixtures/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/instance_template/simple/versions.tf
+++ b/test/fixtures/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/mig/autoscaler/versions.tf
+++ b/test/fixtures/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig/autoscaler/versions.tf
+++ b/test/fixtures/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/mig/simple/versions.tf
+++ b/test/fixtures/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig/simple/versions.tf
+++ b/test/fixtures/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/mig_with_percent/simple/versions.tf
+++ b/test/fixtures/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig_with_percent/simple/versions.tf
+++ b/test/fixtures/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/umig/named_ports/versions.tf
+++ b/test/fixtures/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/named_ports/versions.tf
+++ b/test/fixtures/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/umig/simple/versions.tf
+++ b/test/fixtures/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/simple/versions.tf
+++ b/test/fixtures/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/fixtures/umig/static_ips/versions.tf
+++ b/test/fixtures/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/static_ips/versions.tf
+++ b/test/fixtures/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }

--- a/test/integration/preemptible_and_regular_instance_templates_simple/controls/simple.rb
+++ b/test/integration/preemptible_and_regular_instance_templates_simple/controls/simple.rb
@@ -34,8 +34,8 @@ control "Instance Template" do
 
     describe "kind of templates" do
       it "should be #{expected_disks}" do
-        expect(data[0]['properties']['scheduling']['preemptible']).to be_truthy
-        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_falsey
+        expect(data[0]['properties']['scheduling']['preemptible']).to be_falsey
+        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_truthy
       end
     end
 
@@ -90,8 +90,8 @@ control "Instance Template" do
 
     describe "kind of templates" do
       it "should be #{expected_disks}" do
-        expect(data[0]['properties']['scheduling']['preemptible']).to be_falsey
-        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_truthy
+        expect(data[0]['properties']['scheduling']['preemptible']).to be_truthy
+        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_falsey
       end
     end
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,13 +32,14 @@ provider "random" {
 
 module "project_ci_vm" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 7.0"
+  version = "~> 9.0"
 
-  name              = "ci-vm-module"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-vm-module"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.6"
 }


### PR DESCRIPTION
- We are using `instance-template/disk-variables` branch when declaring TF source for `instance-template/betworks-postgresql/terragrunt.hcl`. That branch is tagged to use TF v0.12.6. 

- Requesting merge master branch into `instance-template/disk-variables` for terraform v0.13 support.

- This branch was created by Rinaldi to support extra variables for our environment.
