### PR TITLE
DEVOPS-1881/protect-betworks-instances-from-deletion-stg-uat

### DIFF
--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -60,5 +60,15 @@ resource "google_compute_instance_from_template" "compute_instance" {
   }
 
   source_instance_template = var.instance_template
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+    ignore_changes = var.ignore_changes
+    [
+      # Ignore changes to tags, e.g. because a management agent
+      # updates these based on some ruleset managed elsewhere.
+      tags,
+    ]
+  }
 }
 

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -64,11 +64,6 @@ resource "google_compute_instance_from_template" "compute_instance" {
   lifecycle {
     prevent_destroy = var.prevent_destroy
     ignore_changes = var.ignore_changes
-    [
-      # Ignore changes to tags, e.g. because a management agent
-      # updates these based on some ruleset managed elsewhere.
-      tags,
-    ]
   }
 }
 

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -64,3 +64,14 @@ variable "region" {
   default     = null
 }
 
+variable "prevent_destroy" {
+  type        = bool
+  description = "Set to true if resource should not be destroyed in case of terraform changes. Default is false."
+  default     = false
+}
+
+variable "ignore_changes" {
+  type        = list
+  description = "List of items to be ignored (if any). This is mostly to avoid recreating a VM because of changes that are cheaper to be done manually (e.g: 'labels')."
+  default     = []
+}


### PR DESCRIPTION
initial draft

Variables in metadata field "lifecycle" are currently not supported.